### PR TITLE
design: 감정키워드 버튼과 이를 사용하는 카드 퍼블리싱

### DIFF
--- a/src/components/common/Buttons/EmotionButton.jsx
+++ b/src/components/common/Buttons/EmotionButton.jsx
@@ -37,19 +37,22 @@ const EmotionButton = ({ possibleClicked = true, clickedImg = false, isText = fa
     { title: '평범해요', clickedImg: NOTBAD_ON_EMOTION, defaultImg: NOTBAD_OFF_EMOTION },
   ];
 
-  const renderEmotion = emotionList.find(({ title }) => {
-    return title === emotionTitle;
-  });
+  const renderEmotion = (emotionList, emotionTitle) => {
+    return emotionList.find(({ title }) => {
+      return title === emotionTitle;
+    });
+  };
 
+  const selectedEmotionImg = renderEmotion(emotionList, emotionTitle);
   return (
     <>
-      {renderEmotion && (
+      {selectedEmotionImg && (
         <StyleButton onClick={onClickedButton}>
           <img
-            src={isClicked === true ? renderEmotion.clickedImg : renderEmotion.defaultImg}
-            alt={renderEmotion.title + '의 감정키워드 이미지'}
+            src={isClicked === true ? selectedEmotionImg.clickedImg : selectedEmotionImg.defaultImg}
+            alt={selectedEmotionImg.title + '의 감정키워드 이미지'}
           />
-          {isText ? <StyleText isClicked={isClicked}>{renderEmotion.title}</StyleText> : <></>}
+          {isText ? <StyleText isClicked={isClicked}>{selectedEmotionImg.title}</StyleText> : <></>}
         </StyleButton>
       )}
     </>

--- a/src/components/common/Buttons/EmotionButton.jsx
+++ b/src/components/common/Buttons/EmotionButton.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import {
+  EMBARRASSMENT_ON_EMOTION,
+  EMBARRASSMENT_OFF_EMOTION,
+  BAD_ON_EMOTION,
+  BAD_OFF_EMOTION,
+  SAD_ON_EMOTION,
+  SAD_OFF_EMOTION,
+  WEIRD_ON_EMOTION,
+  WEIRD_OFF_EMOTION,
+  GOOD_ON_EMOTION,
+  GOOD_OFF_EMOTION,
+  NOTBAD_ON_EMOTION,
+  NOTBAD_OFF_EMOTION,
+} from '../../../styles/CommonImages';
+
+// 클릭가능여부(possibleClicked), 처음렌더될 이미지를 클릭된 이미지로 할지 선택(clickedImg), 텍스트여부(isText), 감정키워드(emotionTitle) 을 props 로 받아서 각 상황에 맞는 버튼을 렌더한다.
+
+const EmotionButton = ({ possibleClicked = true, clickedImg = false, isText = false, emotionTitle = '좋아요' }) => {
+  const [isClicked, setIsClicked] = useState(clickedImg);
+
+  const onClickedButton = () => {
+    if (possibleClicked) {
+      setIsClicked(!isClicked);
+    }
+  };
+
+  const emotionList = [
+    { title: '당황스러워요', clickedImg: EMBARRASSMENT_ON_EMOTION, defaultImg: EMBARRASSMENT_OFF_EMOTION },
+    { title: '별로에요', clickedImg: BAD_ON_EMOTION, defaultImg: BAD_OFF_EMOTION },
+    { title: '속상해요', clickedImg: SAD_ON_EMOTION, defaultImg: SAD_OFF_EMOTION },
+    { title: '이상해요', clickedImg: WEIRD_ON_EMOTION, defaultImg: WEIRD_OFF_EMOTION },
+    { title: '좋아요', clickedImg: GOOD_ON_EMOTION, defaultImg: GOOD_OFF_EMOTION },
+    { title: '평범해요', clickedImg: NOTBAD_ON_EMOTION, defaultImg: NOTBAD_OFF_EMOTION },
+  ];
+
+  const renderEmotion = emotionList.find(({ title }) => {
+    return title === emotionTitle;
+  });
+
+  return (
+    <>
+      {renderEmotion && (
+        <StyleButton onClick={onClickedButton}>
+          <img
+            src={isClicked === true ? renderEmotion.clickedImg : renderEmotion.defaultImg}
+            alt={renderEmotion.title + '의 감정키워드 이미지'}
+          />
+          {isText ? <StyleText isClicked={isClicked}>{renderEmotion.title}</StyleText> : <></>}
+        </StyleButton>
+      )}
+    </>
+  );
+};
+
+export default EmotionButton;
+
+const StyleButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 72px;
+  & img {
+    width: 72px;
+    height: 72px;
+  }
+`;
+
+const StyleText = styled.span`
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 14px;
+  color: ${(props) => (props.isClicked === true ? '#FBB829' : '#D0D0D0')};
+  margin-top: 0.4rem;
+`;

--- a/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
+++ b/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
@@ -21,7 +21,7 @@ const EmotionKeywordCard = () => {
 
   const findMaxCount = (data) => {
     return Math.max.apply(
-      Math,
+      null,
       data.map(({ count }) => {
         return count;
       }),

--- a/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
+++ b/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+
+import { CROWN } from '../../../styles/CommonImages';
+import EmotionButton from '../Buttons/EmotionButton';
+import styled from 'styled-components';
+
+const EmotionKeywordCard = () => {
+  // 임시 더미 데이터
+  const data = [
+    { title: '평범해요', count: 2 },
+    { title: '좋아요', count: 3 },
+    { title: '이상해요', count: 0 },
+    { title: '속상해요', count: 6 },
+    { title: '별로에요', count: 100 },
+    { title: '당황스러워요', count: 14 },
+  ];
+
+  const totalCount = (data) => {
+    return data.map((data) => data.count).reduce((count, init) => count + init, 0);
+  };
+
+  const findMaxCount = (data) => {
+    return Math.max.apply(
+      Math,
+      data.map(({ count }) => {
+        return count;
+      }),
+    );
+  };
+
+  const maxCountIndex = (data) => {
+    return data.findIndex((object) => object.count === findMaxCount(data));
+  };
+
+  return (
+    <StyleCard>
+      <h3 className='sr-only'>감정키워드 카드</h3>
+      <StyleBestEmotion>
+        <img src={CROWN} alt='왕관모양 이미지' />
+        <EmotionButton possibleClicked={false} clickedImg={true} emotionTitle={data[maxCountIndex(data)].title} />
+      </StyleBestEmotion>
+      <StyleStatusWrapper>
+        {data ? (
+          data.map(({ title, count }, index) => (
+            <StyleStatus>
+              {index === maxCountIndex(data) ? (
+                <>
+                  <StyleStatusText color='var(--point-color)'>{title}</StyleStatusText>
+                  <StyleStatusBar color='var(--point-color)' width={(count / totalCount(data)) * 140 + 'px'} />
+                </>
+              ) : (
+                <>
+                  <StyleStatusText color='var(--main-color)'>{title}</StyleStatusText>
+                  <StyleStatusBar color='var(--main-color)' width={(count / totalCount(data)) * 140 + 'px'} />
+                </>
+              )}
+            </StyleStatus>
+          ))
+        ) : (
+          <></>
+        )}
+      </StyleStatusWrapper>
+    </StyleCard>
+  );
+};
+
+export default EmotionKeywordCard;
+
+const StyleCard = styled.section`
+  width: 358px;
+  height: 144px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: raw;
+  background: var(--sub-color);
+  border-radius: 10px;
+`;
+
+const StyleBestEmotion = styled.div`
+  display: inline-flex;
+  position: relative;
+  align-items: flex-end;
+  margin-right: 36px;
+  width: 82px;
+  height: 100px;
+  > img {
+    position: absolute;
+    bottom: 60px;
+    width: 40px;
+    height: 40px;
+  }
+  > button {
+    cursor: default;
+    margin-left: 10px;
+  }
+`;
+
+const StyleStatusWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 216px;
+`;
+
+const StyleStatus = styled.div`
+  display: flex;
+  align-items: center;
+  & + & {
+    margin-top: 4px;
+  }
+`;
+
+const StyleStatusText = styled.span`
+  margin-right: 8px;
+  width: 64px;
+  font-weight: 500;
+  font-size: 12px;
+  color: ${(props) => props.color};
+`;
+
+const StyleStatusBar = styled.div`
+  height: 4px;
+  width: ${(props) => props.width};
+  background-color: ${(props) => props.color};
+  border-radius: 2px;
+`;

--- a/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
+++ b/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
@@ -29,7 +29,8 @@ const EmotionKeywordCard = () => {
   };
 
   const maxCountIndex = (data) => {
-    return data.findIndex((object) => object.count === findMaxCount(data));
+    const FIND_MAX_COUNT = findMaxCount(data);
+    return data.findIndex((object) => object.count === FIND_MAX_COUNT);
   };
 
   return (

--- a/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
+++ b/src/components/common/EmotionKeywordCard/EmotionKeywordCard.jsx
@@ -42,7 +42,7 @@ const EmotionKeywordCard = () => {
       <StyleStatusWrapper>
         {data ? (
           data.map(({ title, count }, index) => (
-            <StyleStatus>
+            <StyleStatus key={'감정키워드상태_' + title}>
               {index === maxCountIndex(data) ? (
                 <>
                   <StyleStatusText color='var(--point-color)'>{title}</StyleStatusText>
@@ -96,13 +96,13 @@ const StyleBestEmotion = styled.div`
   }
 `;
 
-const StyleStatusWrapper = styled.div`
+const StyleStatusWrapper = styled.ul`
   display: flex;
   flex-direction: column;
   width: 216px;
 `;
 
-const StyleStatus = styled.div`
+const StyleStatus = styled.li`
   display: flex;
   align-items: center;
   & + & {

--- a/src/styles/CommonImages.jsx
+++ b/src/styles/CommonImages.jsx
@@ -1,0 +1,29 @@
+import EMBARRASSMENT_ON_EMOTION from '../assets/images/당황스러워요_on.png';
+import EMBARRASSMENT_OFF_EMOTION from '../assets/images/당황스러워요_off.png';
+import BAD_ON_EMOTION from '../assets/images/별로에요_on.png';
+import BAD_OFF_EMOTION from '../assets/images/별로에요_off.png';
+import SAD_ON_EMOTION from '../assets/images/속상해요_on.png';
+import SAD_OFF_EMOTION from '../assets/images/속상해요_off.png';
+import WEIRD_ON_EMOTION from '../assets/images/이상해요_on.png';
+import WEIRD_OFF_EMOTION from '../assets/images/이상해요_off.png';
+import GOOD_ON_EMOTION from '../assets/images/좋아요_on.png';
+import GOOD_OFF_EMOTION from '../assets/images/좋아요_off.png';
+import NOTBAD_ON_EMOTION from '../assets/images/평범해요_on.png';
+import NOTBAD_OFF_EMOTION from '../assets/images/평범해요_off.png';
+import CROWN from '../assets/images/crown.png';
+
+export {
+  EMBARRASSMENT_ON_EMOTION,
+  EMBARRASSMENT_OFF_EMOTION,
+  BAD_ON_EMOTION,
+  BAD_OFF_EMOTION,
+  SAD_ON_EMOTION,
+  SAD_OFF_EMOTION,
+  WEIRD_ON_EMOTION,
+  WEIRD_OFF_EMOTION,
+  GOOD_ON_EMOTION,
+  GOOD_OFF_EMOTION,
+  NOTBAD_ON_EMOTION,
+  NOTBAD_OFF_EMOTION,
+  CROWN,
+};


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 감정키워드로 사용될 버튼과 그 버튼을 활용하여 나타나는 카드를 사용하고자 퍼블리싱을 완료하였습니다.


## 기대 결과
- 설정한 데이터에 맞게 퍼블리싱된 이미지가 렌더될 것 입니다.


## 리뷰어에게 전달 사항
- 확인부탁드려요~!


## 스크린샷
<img width="363" alt="감정키워드" src="https://user-images.githubusercontent.com/57481378/212554819-87224a32-3f90-448a-9972-fa99f09f4a98.png">


## 관련 이슈 번호
close : #3 
