### PR TITLE
design: 크기별 버튼 UI 추가 (#6)

### DIFF
--- a/src/components/common/Buttons/BasicButton.jsx
+++ b/src/components/common/Buttons/BasicButton.jsx
@@ -5,7 +5,8 @@ const BasicButton = ({
   children,
   size,
   disabled,
-  backgroundColor = 'var(--main-color)',
+  backgroundColor = 'var(--main-color)', // 취소 기본 배경: #D1D1D1
+  activeBgColor = 'var(--point-color)', // 취소 액티브 배경: #E9E9E9
   textColor = 'var(--bg-color)',
   type,
   onClickHandler,
@@ -16,6 +17,7 @@ const BasicButton = ({
       size={size}
       disabled={disabled}
       backgroundColor={backgroundColor}
+      activeBgColor={activeBgColor}
       textColor={textColor}
       type={type}
       onClick={onClickHandler}
@@ -37,12 +39,8 @@ const ButtonSize = css`
           height: 56px;
           border-radius: 16px;
 
-          & {
-            background: ${(props) => (props.disabled === true ? 'var(--sub-color)' : 'var(--main-color)')};
-          }
-
           &:active:not(:disabled) {
-            background: var(--point-color);
+            background: ${(props) => props.activeBgColor};
           }
         `;
 
@@ -52,12 +50,8 @@ const ButtonSize = css`
           height: 48px;
           border-radius: 16px;
 
-          & {
-            background: ${(props) => (props.disabled === true ? 'var(--sub-color)' : 'var(--main-color)')};
-          }
-
           &:active:not(:disabled) {
-            background: var(--point-color);
+            background: ${(props) => props.activeBgColor};
           }
         `;
 
@@ -67,12 +61,8 @@ const ButtonSize = css`
           height: 54px;
           border-radius: 16px;
 
-          & {
-            background: ${(props) => (props.children === '등록하기' ? 'var(--main-color)' : '#E9E9E9')};
-          }
-
-          &:active {
-            background: ${(props) => (props.children === '등록하기' ? 'var(--point-color)' : '#D1D1D1')};
+          &:active:not(:disabled) {
+            background: ${(props) => props.activeBgColor};
           }
         `;
 
@@ -82,12 +72,8 @@ const ButtonSize = css`
           height: 36px;
           border-radius: 6px;
 
-          & {
-            background: ${(props) => (props.disabled === true ? 'var(--sub-color)' : 'var(--main-color)')};
-          }
-
           &:active:not(:disabled) {
-            background: var(--point-color);
+            background: ${(props) => props.activeBgColor};
           }
         `;
 

--- a/src/components/common/Buttons/BasicButton.jsx
+++ b/src/components/common/Buttons/BasicButton.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import styled, { css } from 'styled-components';
+
+const BasicButton = ({
+  children,
+  size,
+  disabled,
+  backgroundColor = 'var(--main-color)',
+  textColor = 'var(--bg-color)',
+  type,
+  onClickHandler,
+  isActive = true,
+}) => {
+  return (
+    <StyledButton
+      size={size}
+      disabled={disabled}
+      backgroundColor={backgroundColor}
+      textColor={textColor}
+      type={type}
+      onClick={onClickHandler}
+      isActive={isActive}
+    >
+      {children}
+    </StyledButton>
+  );
+};
+
+export default BasicButton;
+
+const ButtonSize = css`
+  ${({ size }) => {
+    switch (size) {
+      case 'L':
+        return css`
+          width: 350px;
+          height: 56px;
+          border-radius: 16px;
+
+          & {
+            background: ${(props) => (props.disabled === true ? 'var(--sub-color)' : 'var(--main-color)')};
+          }
+
+          &:active:not(:disabled) {
+            background: var(--point-color);
+          }
+        `;
+
+      case 'M':
+        return css`
+          width: 322px;
+          height: 48px;
+          border-radius: 16px;
+
+          & {
+            background: ${(props) => (props.disabled === true ? 'var(--sub-color)' : 'var(--main-color)')};
+          }
+
+          &:active:not(:disabled) {
+            background: var(--point-color);
+          }
+        `;
+
+      case 'S':
+        return css`
+          width: 140px;
+          height: 54px;
+          border-radius: 16px;
+
+          & {
+            background: ${(props) => (props.children === '등록하기' ? 'var(--main-color)' : '#E9E9E9')};
+          }
+
+          &:active {
+            background: ${(props) => (props.children === '등록하기' ? 'var(--point-color)' : '#D1D1D1')};
+          }
+        `;
+
+      case 'XS':
+        return css`
+          width: 40px;
+          height: 36px;
+          border-radius: 6px;
+
+          & {
+            background: ${(props) => (props.disabled === true ? 'var(--sub-color)' : 'var(--main-color)')};
+          }
+
+          &:active:not(:disabled) {
+            background: var(--point-color);
+          }
+        `;
+
+      default:
+        return;
+    }
+  }}
+`;
+
+// 버튼의 기본 스타일
+const StyledButton = styled.button`
+  ${ButtonSize}
+  margin: 0 auto;
+  outline: none;
+  box-sizing: border-box;
+  font-size: var(--fs-lg);
+  color: ${(props) => props.textColor};
+  background: ${(props) => props.backgroundColor};
+`;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 각 페이지에서 공통으로 사용될 버튼을 위하여 퍼블리싱 하였습니다.


## 기대 결과
- props 전달값에 따라 button 태그의 크기와 색상이 다르게 나타날 것 입니다.


## 리뷰어에게 전달 사항
- 모달에 사용되는 [등록하기 / 취소] 버튼 부분은
children = '등록하기' 삼항연산자를 이용해서 색상을 다르게 변경할 수 있도록 로직을 작성해봤는데
추후에 다른 모달이 추가되고 버튼의 텍스트 내용이 달라질 경우에 번거로운 작업이 될까요?


## 스크린샷
<img width="389" alt="BE평 공통 UI - 베이직버튼" src="https://user-images.githubusercontent.com/91003855/212621486-a74ab621-9b7e-44df-815a-7593a71bd59b.png">


## 관련 이슈 번호
close : #6 
