### PR TITLE
design: 알림 페이지 UI 퍼블리싱 작업

### DIFF
--- a/src/components/common/AppBar/TabPageAppBar.jsx
+++ b/src/components/common/AppBar/TabPageAppBar.jsx
@@ -40,7 +40,7 @@ const StyleAppBarWrapper = styled.header`
   height: 48px;
   padding: 0.8em 1.2em 0.8em 1.6em;
   z-index: 100;
-  background-color: transparent;
+  background-color: var(--main-bg-color);
 `;
 
 const StyleTapPageTitle = styled.h1`

--- a/src/components/common/NoticeList/NoticeList.jsx
+++ b/src/components/common/NoticeList/NoticeList.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { NOTICE_REPORT, NOTICE_EVALUATE, NOTICE_ASSESSMENT_CLOSING } from '../../../styles/CommonIcons';
 
-const Notice = () => {
+const NoticeList = () => {
   return (
     <StyleNoticeListWrapper>
       <StyleNoticeListLi>
@@ -34,7 +34,7 @@ const Notice = () => {
   );
 };
 
-export default Notice;
+export default NoticeList;
 
 const StyleNoticeListWrapper = styled.ul`
   width: 100%;

--- a/src/pages/NoticePage/NoticePage.jsx
+++ b/src/pages/NoticePage/NoticePage.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import TabPageAppBar from 'components/common/AppBar/TabPageAppBar';
+import ContentsLayout from 'components/layout/ContentsLayout/ContentsLayout';
+import NoticeList from 'components/common/NoticeList/NoticeList';
+import BasicButton from 'components/common/Buttons/BasicButton';
+import styled from 'styled-components';
+
+const NoticePage = () => {
+  return (
+    <NoticeMain>
+      <TabPageAppBar isTapPage={false} tabPageName='알림함' btnList={['체크']} />
+      <ContentsLayout padding='0'>
+        <NoticeList />
+      </ContentsLayout>
+      <NoticeCheckButton size='L'>전체확인</NoticeCheckButton>
+    </NoticeMain>
+  );
+};
+
+export default NoticePage;
+
+const NoticeMain = styled.main`
+  display: flex;
+  flex-direction: column;
+`;
+
+const NoticeCheckButton = styled(BasicButton)`
+  width: 350px;
+  position: fixed;
+  text-align: center;
+  left: 50%;
+  bottom: 80px;
+  transform: translateX(-50%);
+`;

--- a/src/pages/NoticePage/NoticePage.jsx
+++ b/src/pages/NoticePage/NoticePage.jsx
@@ -7,22 +7,17 @@ import styled from 'styled-components';
 
 const NoticePage = () => {
   return (
-    <NoticeMain>
+    <>
       <TabPageAppBar isTapPage={false} tabPageName='알림함' btnList={['체크']} />
       <ContentsLayout padding='0'>
         <NoticeList />
       </ContentsLayout>
       <NoticeCheckButton size='L'>전체확인</NoticeCheckButton>
-    </NoticeMain>
+    </>
   );
 };
 
 export default NoticePage;
-
-const NoticeMain = styled.main`
-  display: flex;
-  flex-direction: column;
-`;
 
 const NoticeCheckButton = styled(BasicButton)`
   width: 350px;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 알림 페이지 UI 퍼블리싱을 위해 추가했습니당


## 기대 결과
- 피그마 시안과 같습니당


## 리뷰어에게 전달 사항
- 스크롤 시에 메인과 헤더의 컨텐츠 영역이 겹쳐보입니닷.
- 헤더의 배경색을 투명에서 현재 메인의 배경bg로 바꾸는 것은 어떨까요오?


## 스크린샷
<img width="351" alt="BE평 - 알림함 페이지" src="https://user-images.githubusercontent.com/91003855/214049718-16f71fe8-26ad-4e07-8b28-960f77125901.png">


## 관련 이슈 번호
close : #40
