### PR TITLE
design: 광고 배너 관리 페이지 UI 퍼블리싱 작업

### DIFF
--- a/src/pages/AdBannerPage/AdBannerPage.jsx
+++ b/src/pages/AdBannerPage/AdBannerPage.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import TabPageAppBar from 'components/common/AppBar/TabPageAppBar';
+import ContentsLayout from 'components/layout/ContentsLayout/ContentsLayout';
+import PostImgAddButton from 'components/common/Buttons/PostImgAddButton';
+import PostImgDeleteButton from 'components/common/Buttons/PostImgDeleteButton';
+import BasicButton from 'components/common/Buttons/BasicButton';
+
+const AdBannerPage = () => {
+  return (
+    <>
+      <TabPageAppBar isTapPage={false} tabPageName='광고 배너 관리' />
+      <ContentsLayout padding='2rem 1.6rem 0 1.6rem'>
+        <StyleForm>
+          <AdBannerWrapper>
+            <PostImgAddButton />
+            <PostImgDeleteButton />
+            <PostImgDeleteButton />
+            {/* TODO: <PostImgDeleteButton /> 가 추가 되면, <PostInputOption/>의 wrap을 nowrap으로 바꿔주기 */}
+          </AdBannerWrapper>
+          <UploadButton size='L' className>
+            작성하기
+          </UploadButton>
+        </StyleForm>
+      </ContentsLayout>
+    </>
+  );
+};
+
+export default AdBannerPage;
+
+const StyleForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const AdBannerWrapper = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 18px;
+  overflow-x: auto;
+`;
+
+const UploadButton = styled(BasicButton)`
+  max-width: 350px;
+  position: fixed;
+  bottom: 34px;
+  left: 50%;
+  transform: translateX(-50%);
+`;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 광고 배너 관리 페이지 화면 개발을 위해 추가했습니닷


## 리뷰어에게 전달 사항
- '추가된 사진(엑스버튼 함께있는 이미지)'의 코드는 대체 이미지(핑크색 뿅망치가 있는 BE평 이미지)대신 사진이 비어있는 상태로 두었습니닷
- 추후에 기능 개발할 때에 추가한 이미지가 보여지는 형태로 만들 예정입니닷


## 스크린샷
<img width="350" alt="BE평 - 광고 배너 관리 페이지" src="https://user-images.githubusercontent.com/91003855/214247540-230fe6bc-84ae-4484-98a1-7160ff536515.png">


## 관련 이슈 번호
close : #51 
