### PR TITLE
design: 관심목록 화면 퍼블리싱 및 공통 토스트팝업 UI 구현

### DIFF
--- a/src/components/RatingToastPopup/RatingToastPopup.jsx
+++ b/src/components/RatingToastPopup/RatingToastPopup.jsx
@@ -1,0 +1,103 @@
+import BasicButton from 'components/common/Buttons/BasicButton';
+import EmotionButton from 'components/common/Buttons/EmotionButton';
+import StarRateButton from 'components/common/Buttons/StarRateButton';
+import React from 'react';
+import styled from 'styled-components';
+
+const RatingToastPopup = () => {
+  return (
+    <StyleWrapper>
+      <h2 className='sr-only'>토스트팝업</h2>
+      <StyleToastPopup>
+        <RatingTitle>별점</RatingTitle>
+        <StarRateButton />
+        <RatingTitle>감정키워드</RatingTitle>
+        <EmotionKeywordWrapper>
+          <li>
+            <EmotionButton emotionTitle='평범해요' isText={true} />
+          </li>
+          <li>
+            <EmotionButton emotionTitle='좋아요' isText={true} />
+          </li>
+          <li>
+            <EmotionButton emotionTitle='당황스러워요' isText={true} />
+          </li>
+          <li>
+            <EmotionButton emotionTitle='이상해요' isText={true} />
+          </li>
+          <li>
+            <EmotionButton emotionTitle='별로에요' isText={true} />
+          </li>
+          <li>
+            <EmotionButton emotionTitle='속상해요' isText={true} />
+          </li>
+        </EmotionKeywordWrapper>
+        <BasicButton size='L' isActive={false} disabled={true} type='submit'>
+          {'평가하기'}
+        </BasicButton>
+      </StyleToastPopup>
+    </StyleWrapper>
+  );
+};
+
+export default RatingToastPopup;
+
+const StyleWrapper = styled.section`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 9800;
+`;
+
+const StyleToastPopup = styled.article`
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  height: 698px;
+  max-width: 39rem;
+  padding: 1.6rem 0 1rem 0;
+  border-radius: 16px 16px 0 0;
+  background-color: var(--main-bg-color);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  ::before {
+    content: '';
+    display: block;
+    width: 13.4rem;
+    height: 4px;
+    margin: 0 auto 2.4rem auto;
+    background-color: var(--border-color);
+  }
+`;
+
+const RatingTitle = styled.h3`
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 20px;
+  width: 152px;
+  height: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #222222;
+  margin-bottom: 16px;
+  div + & {
+    margin-top: 40px;
+  }
+`;
+
+const EmotionKeywordWrapper = styled.ul`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  column-gap: 63px;
+  row-gap: 24px;
+  margin-bottom: 182px;
+`;

--- a/src/components/common/BasicToastPopup/BasicToastPopup.jsx
+++ b/src/components/common/BasicToastPopup/BasicToastPopup.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BasicToastPopup = () => {
+  return (
+    <StyleWrapper>
+      <h2 className='sr-only'>토스트팝업</h2>
+      <StyleToastPopup>
+        <MenuItem>
+          <button type='button'>설정 및 개인정보</button>
+        </MenuItem>
+        <MenuItem>
+          <button type='button'>로그아웃</button>
+        </MenuItem>
+      </StyleToastPopup>
+    </StyleWrapper>
+  );
+};
+
+export default BasicToastPopup;
+
+const StyleWrapper = styled.section`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 9800;
+`;
+
+const StyleToastPopup = styled.article`
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 39rem;
+  padding: 1.6rem 0 1rem 0;
+  border-radius: 10px 10px 0 0;
+  background-color: var(--main-bg-color);
+
+  ::before {
+    content: '';
+    display: block;
+    width: 13.4rem;
+    height: 4px;
+    margin: 0 auto 2.4rem auto;
+    background-color: var(--border-color);
+  }
+`;
+
+const MenuItem = styled.li`
+  padding-left: 2.6rem;
+
+  & > * {
+    display: block;
+    width: 100%;
+    padding: 1.4rem 0;
+    text-align: left;
+    font-size: var(--fs-md);
+  }
+`;

--- a/src/pages/FavoriteFeedsPage/FavoriteFeedsPage.jsx
+++ b/src/pages/FavoriteFeedsPage/FavoriteFeedsPage.jsx
@@ -1,0 +1,21 @@
+import TabPageAppBar from 'components/common/AppBar/TabPageAppBar';
+import FeedList from 'components/common/FeedList/FeedList';
+import TabBar from 'components/common/TabBar/TabBar';
+import TagComponent from 'components/common/TagComponent/TagComponent';
+import ContentsLayout from 'components/layout/ContentsLayout/ContentsLayout';
+import React from 'react';
+
+const FavoriteFeedsPage = () => {
+  return (
+    <>
+      <TabPageAppBar btnList={['검색', '알림']} isTapPage={true} tabPageName='관심목록' />
+      <ContentsLayout padding='0'>
+        <TagComponent />
+        <FeedList />
+      </ContentsLayout>
+      <TabBar tabPage='Tab_Favorites' />
+    </>
+  );
+};
+
+export default FavoriteFeedsPage;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 관심목록 화면 퍼블리싱 및 공통 토스트팝업 UI 구현하기 위한 코드 추가


## 기대 결과
- 피그마 시안과 동일한 UI 를 확인할 수 있습니다.


## 리뷰어에게 전달 사항
- 확인부탁드려요오옹🌸


## 스크린샷
![관심목록](https://user-images.githubusercontent.com/57481378/214377741-a0ee8176-56cc-460d-9340-459b38f34b34.png)
![토스트팝업_기본](https://user-images.githubusercontent.com/57481378/214377762-6c20450c-dd5c-40e7-baf7-719e7f6b28d0.png)


## 관련 이슈 번호
close : #64 
